### PR TITLE
feat: 문자정보 관련 문서 생성 및 작성

### DIFF
--- a/apps/seroi/pages/laundry/domain/_meta.json
+++ b/apps/seroi/pages/laundry/domain/_meta.json
@@ -1,5 +1,6 @@
 {
   "complex": "Complex 컴플렉스",
   "container": "Container 컨테이너",
-  "order": "Order 주문"
+  "order": "Order 주문",
+  "messageinfo": "MessageInfo 문자정보"
 }

--- a/apps/seroi/pages/laundry/domain/messageinfo.mdx
+++ b/apps/seroi/pages/laundry/domain/messageinfo.mdx
@@ -3,8 +3,8 @@ import { Parameters, Heading } from '@docs/ui';
 
 <Heading title="MessageInfo란?" />
 
-`MessageInfo` 는 알리고(문자 전송 시스템) 계정 정보를 기록하기 위한 하나의 Container입니다. <br />
-알리고의 계정정보 1개 당 1개의 `MessageInfo`타입의 `Doc`이 생성됩니다. <br /> <br />
+`MessageInfo` 는 알리고(문자 전송 시스템) 계정 정보를 기록하기 위한 Container 입니다. <br />
+알리고의 계정 정보 1개 당 1개의 `MessageInfo` 타입의 `Doc`이 생성됩니다. <br /> <br />
 
 \*참고 : [알리고](https://smartsms.aligo.in/)
 

--- a/apps/seroi/pages/laundry/domain/messageinfo.mdx
+++ b/apps/seroi/pages/laundry/domain/messageinfo.mdx
@@ -1,0 +1,19 @@
+import { SVCMessageAttributes } from '../../../src/constant/laundry';
+import { Parameters, Heading } from '@docs/ui';
+
+<Heading title="MessageInfo란?" />
+
+`MessageInfo` 는 알리고(문자 전송 시스템) 계정 정보를 기록하기 위한 하나의 Container입니다. <br />
+알리고의 계정정보 1개 당 1개의 `MessageInfo`타입의 `Doc`이 생성됩니다. <br /> <br />
+
+\*참고 : [알리고](https://smartsms.aligo.in/)
+
+<br />
+
+<Heading title="SVCMessageInfo 컨테이너" type="doc" />
+<Parameters title="데이터 형식" attributes={SVCMessageAttributes.root} />
+<br />
+<Heading title="LaundryMessage 문자" type="userData" />
+문자의 고유정보 입니다.
+<Parameters title="데이터 형식" attributes={SVCMessageAttributes.userData} />
+<br />

--- a/apps/seroi/src/constant/laundry/SVCMessageAttributes.ts
+++ b/apps/seroi/src/constant/laundry/SVCMessageAttributes.ts
@@ -4,12 +4,12 @@ import attributes from '../attributes';
 const SVCMessage: Attribute[] = [
   { ...attributes.type, description: 'Doc의 Type입니다. "MESSAGEINFO"로 고정 값 입니다.' },
   attributes.id,
-  { ...attributes.bucketId, description: '문자의 버킷 ID값 입니다. 고유 값 입니다.(SVCBucket_881050921521152)' },
+  { ...attributes.bucketId, description: '문자의 버킷 ID값 입니다. 고유 값 입니다. (SVCBucket_881050921521152)' },
   {
     name: 'title',
     required: true,
     type: 'string',
-    description: '문자 내용 앞에 들어갈 제목입니다. \n ex)[무인세탁함] TEST 세탁함에 세탁이 완료되었습니다. 의 문자 내용에서 "무인세탁함" 을 말합니다.',
+    description: '문자 내용 앞에 들어갈 제목입니다. \nex) [무인세탁함] TEST 세탁함에 세탁이 완료되었습니다. 의 문자 내용에서 "무인세탁함" 을 말합니다.',
   },
   attributes.deleted,
   attributes.published,

--- a/apps/seroi/src/constant/laundry/SVCMessageAttributes.ts
+++ b/apps/seroi/src/constant/laundry/SVCMessageAttributes.ts
@@ -1,0 +1,30 @@
+import { Attribute } from '@docs/ui/src/types/list.type';
+import attributes from '../attributes';
+
+const SVCMessage: Attribute[] = [
+  { ...attributes.type, description: 'Doc의 Type입니다. "MESSAGEINFO"로 고정 값 입니다.' },
+  attributes.id,
+  { ...attributes.bucketId, description: '문자의 버킷 ID값 입니다. 고유 값 입니다.(SVCBucket_881050921521152)' },
+  {
+    name: 'title',
+    required: true,
+    type: 'string',
+    description: '문자 내용 앞에 들어갈 제목입니다. \n ex)[무인세탁함] TEST 세탁함에 세탁이 완료되었습니다. 의 문자 내용에서 "무인세탁함" 을 말합니다.',
+  },
+  attributes.deleted,
+  attributes.published,
+  attributes.updated,
+  attributes.created,
+  { ...attributes.userData, type: 'LaundryMessage', description: '문자의 고유정보를 나타냅니다.' },
+];
+
+const userData: Attribute[] = [
+  { name: 'apiKey', required: true, type: 'string', description: '알리고 계정의 API키 값 입니다.' },
+  { name: 'senderPhoneNumber', required: true, type: 'string', description: '문자 전송 시 발신 번호로 표시될 번호 값 입니다.' },
+  { name: 'userId', required: true, type: 'string', description: '알리고 계정의 ID 값 입니다.' },
+];
+
+export default {
+  root: SVCMessage,
+  userData: userData,
+};

--- a/apps/seroi/src/constant/laundry/index.ts
+++ b/apps/seroi/src/constant/laundry/index.ts
@@ -1,3 +1,4 @@
 export { default as SVCComplexAttributes } from './SVCComplexAttributes';
 export { default as SVCContainerAttributes } from './SVCContainerAttributes';
 export { default as SVCOrderAttributes } from './SVCOrderAttributes';
+export { default as SVCMessageAttributes } from './SVCMessageAttributes';


### PR DESCRIPTION
## 문서 주제

- 문자정보 관련 문서 생성 및 작성

## optional 문서 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 문자에 관한 정보를 저장할 곳이 따로 없어서, doc형태로 만들었었고 doc의 userData안에 apikey와 계정정보가 저장되어있습니다.
이것이 추후에 문제가 될 수도있을것 같긴한데, 우선은 이렇게 사용하고 있습니다.
현재 알리고 계정정보는 총 3개(doc도 3개)가 있으며, 주로 이루미의 알리고 계정을 사용 중입니다. 
위와 관련된 내용을 docs문서에도 표시하면 좋을지 말지 의견 부탁드리겠습니다. 

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
